### PR TITLE
Split QBackendProcess into a more generic QBackendConnection

### DIFF
--- a/plugin/plugin.cpp
+++ b/plugin/plugin.cpp
@@ -1,12 +1,14 @@
 #include "plugin.h"
 #include <QQmlEngine>
 
+#include "qbackendconnection.h"
 #include "qbackendprocess.h"
 #include "qbackendjsonlistmodel.h"
 #include "qbackendstore.h"
 
 void QBackendPlugin::registerTypes(const char *uri)
 {
+    qmlRegisterType<QBackendConnection>(uri, 1, 0, "BackendConnection");
     qmlRegisterType<QBackendProcess>(uri, 1, 0, "BackendProcess");
     qmlRegisterType<QBackendJsonListModel>(uri, 1, 0, "BackendJsonListModel");
     qmlRegisterType<QBackendStore>(uri, 1, 0, "BackendStore");

--- a/plugin/plugin.pro
+++ b/plugin/plugin.pro
@@ -13,6 +13,7 @@ INSTALLS += qmldir
 
 SOURCES += \
     plugin.cpp \
+    qbackendconnection.cpp \
     qbackendprocess.cpp \
     qbackendjsonlistmodel.cpp \
     qbackendabstractconnection.cpp \
@@ -20,6 +21,7 @@ SOURCES += \
 
 HEADERS += \
     plugin.h \
+    qbackendconnection.h \
     qbackendprocess.h \
     qbackendjsonlistmodel.h \
     qbackendabstractconnection.h \

--- a/plugin/qbackendconnection.cpp
+++ b/plugin/qbackendconnection.cpp
@@ -1,0 +1,202 @@
+#include <QDebug>
+#include <QJsonDocument>
+#include <QJsonArray>
+#include <QJsonObject>
+#include <QLoggingCategory>
+#include <QLocalSocket>
+
+#include "qbackendconnection.h"
+
+// #define PROTO_DEBUG
+
+Q_LOGGING_CATEGORY(lcConnection, "backend.connection")
+Q_LOGGING_CATEGORY(lcProto, "backend.proto")
+Q_LOGGING_CATEGORY(lcProtoExtreme, "backend.proto.extreme", QtWarningMsg)
+
+QBackendConnection::QBackendConnection(QObject *parent)
+    : QBackendAbstractConnection(parent)
+{
+}
+
+QUrl QBackendConnection::url() const
+{
+    return m_url;
+}
+
+void QBackendConnection::setUrl(const QUrl& url)
+{
+    m_url = url;
+    emit urlChanged();
+
+    qCInfo(lcConnection) << "Opening URL" << url;
+
+    if (url.scheme() == "fd") {
+        // fd:0 (rw) or fd:0,1 (r,w)
+        QStringList values = url.path().split(",");
+        int rdFd = -1, wrFd = -1;
+        bool ok = false;
+        if (values.size() == 2) {
+            rdFd = values[0].toInt(&ok);
+            if (!ok)
+                rdFd = -1;
+            wrFd = values[1].toInt(&ok);
+            if (!ok)
+                wrFd = -1;
+        } else if (values.size() == 1) {
+            rdFd = wrFd = values[0].toInt(&ok);
+            if (!ok)
+                rdFd = wrFd = -1;
+        }
+
+        if (rdFd < 0 || wrFd < 0) {
+            qCritical() << "Invalid QBackendConnection url" << url;
+            return;
+        }
+
+        QLocalSocket *rd = new QLocalSocket(this);
+        if (!rd->setSocketDescriptor(rdFd)) {
+            qCritical() << "QBackendConnection failed for read fd:" << rd->errorString();
+            return;
+        }
+
+        QLocalSocket *wr = nullptr;
+        if (rdFd == wrFd) {
+            wr = rd;
+        } else {
+            wr = new QLocalSocket(this);
+            if (!wr->setSocketDescriptor(wrFd)) {
+                qCritical() << "QBackendConnection failed for write fd:" << wr->errorString();
+                return;
+            }
+        }
+
+        setBackendIo(rd, wr);
+    } else {
+        qCritical() << "Unknown QBackendConnection scheme" << url.scheme();
+        return;
+    }
+}
+
+void QBackendConnection::setBackendIo(QIODevice *rd, QIODevice *wr)
+{
+    if (m_readIo || m_writeIo) {
+        qFatal("QBackendConnection IO cannot be reset");
+        return;
+    }
+
+    m_readIo = rd;
+    m_writeIo = wr;
+
+    if (m_pendingData.length()) {
+        for (const QByteArray& data : m_pendingData) {
+            write(data);
+        }
+        m_pendingData.clear();
+    }
+
+    connect(m_readIo, &QIODevice::readyRead, this, &QBackendConnection::handleModelDataReady);
+    handleModelDataReady();
+}
+
+QJsonDocument QBackendConnection::readJsonBlob(int byteCount)
+{
+    QByteArray cmdBuf;
+    while (cmdBuf.length() < byteCount) {
+        qCDebug(lcProtoExtreme) << "Want " << byteCount << " bytes, have " << cmdBuf.length();
+        m_readIo->waitForReadyRead(10);
+        cmdBuf += m_readIo->read(byteCount - cmdBuf.length());
+    }
+    Q_ASSERT(cmdBuf.length() == byteCount);
+    QJsonParseError pe;
+    QJsonDocument doc = QJsonDocument::fromJson(cmdBuf, &pe);
+    if (doc.isNull()) {
+        qCWarning(lcProto) << "Bad blob: " << cmdBuf << pe.errorString();
+    }
+    return doc;
+}
+
+void QBackendConnection::handleModelDataReady()
+{
+    while (m_readIo->canReadLine()) {
+        qCDebug(lcProtoExtreme) << "Reading...";
+        QByteArray cmdBuf = m_readIo->readLine();
+        if (cmdBuf == "\n") {
+            // ignore
+            continue;
+        }
+
+#if defined(PROTO_DEBUG)
+        qCDebug(lcProto) << "Read " << cmdBuf;
+#endif
+        if (cmdBuf.startsWith("VERSION ")) {
+            // First, remove the newline.
+            cmdBuf.truncate(cmdBuf.length() - 1);
+            QList<QByteArray> parts = cmdBuf.split(' ');
+            Q_ASSERT(parts.length() == 2);
+            qCInfo(lcConnection) << "Connected to backend version " << parts[1];
+        } else if (cmdBuf.startsWith("OBJECT_CREATE ")) {
+            // First, remove the newline.
+            cmdBuf.truncate(cmdBuf.length() - 1);
+
+            QList<QByteArray> parts = cmdBuf.split(' ');
+            Q_ASSERT(parts.length() == 2);
+            QByteArray identifier = QByteArray(parts[1]);
+
+            QJsonDocument doc = readJsonBlob(parts[2].toInt());
+            if (m_subscribedObjects.contains(identifier)) {
+                m_subscribedObjects[identifier]->objectFound(doc);
+            } else {
+                qCWarning(lcConnection) << "Got creation for unsubscribed identifier: " << identifier << doc;
+            }
+        } else if (cmdBuf.startsWith("EMIT ")) {
+            // First, remove the newline.
+            cmdBuf.truncate(cmdBuf.length() - 1);
+
+            QList<QByteArray> parts = cmdBuf.split(' ');
+            Q_ASSERT(parts.length() == 3);
+            QByteArray identifier = QByteArray(parts[1]);
+
+            QJsonDocument doc = readJsonBlob(parts[3].toInt());
+
+            if (m_subscribedObjects.contains(identifier)) {
+                qCDebug(lcConnection) << "Emit " << parts[2] << " on " << parts[1] << doc.toVariant();
+                m_subscribedObjects[identifier]->methodInvoked(parts[2], doc);
+            } else {
+                qCWarning(lcConnection) << "Got method emit for unsubscribed identifier: " << identifier << doc;
+            }
+        }
+    }
+}
+
+void QBackendConnection::write(const QByteArray& data)
+{
+    if (!m_writeIo) {
+        qCDebug(lcProtoExtreme) << "Write on an inactive connection buffered: " << data;
+        m_pendingData.append(data);
+        return;
+    }
+
+#if defined(PROTO_DEBUG)
+    qCDebug(lcProto) << "Writing " << data;
+#endif
+    m_writeIo->write(data);
+}
+
+void QBackendConnection::invokeMethod(const QByteArray& identifier, const QString& method, const QByteArray& jsonData)
+{
+    qCDebug(lcConnection) << "Invoking " << identifier << method << jsonData;
+    QString data = "INVOKE " + identifier + " " + method + " " + QString::number(jsonData.length()) + "\n";
+    write(data.toUtf8());
+    write(jsonData + '\n');
+}
+
+// ### unsubscribe
+void QBackendConnection::subscribe(const QByteArray& identifier, QBackendRemoteObject* object)
+{
+    qCDebug(lcConnection) << "Creating remote object handler " << identifier << " on connection " << this << " for " << object;
+    m_subscribedObjects[identifier] = object;
+    QString data = "SUBSCRIBE " + identifier + "\n";
+    write(data.toUtf8());
+}
+
+

--- a/plugin/qbackendconnection.h
+++ b/plugin/qbackendconnection.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <QObject>
+#include <QQmlParserStatus>
+#include <QIODevice>
+#include <QUrl>
+
+#include "qbackendabstractconnection.h"
+
+class QBackendConnection : public QBackendAbstractConnection
+{
+    Q_OBJECT
+    Q_PROPERTY(QUrl url READ url WRITE setUrl NOTIFY urlChanged)
+
+public:
+    QBackendConnection(QObject *parent = 0);
+
+    QUrl url() const;
+    void setUrl(const QUrl& url);
+
+    void invokeMethod(const QByteArray& identifier, const QString& method, const QByteArray& jsonData) override;
+    void subscribe(const QByteArray& identifier, QBackendRemoteObject* object) override;
+
+signals:
+    void urlChanged();
+
+protected:
+    void setBackendIo(QIODevice *read, QIODevice *write);
+
+private slots:
+    void handleModelDataReady();
+
+private:
+    QUrl m_url;
+    QIODevice *m_readIo = nullptr;
+    QIODevice *m_writeIo = nullptr;
+    QList<QByteArray> m_pendingData;
+
+    QJsonDocument readJsonBlob(int byteCount);
+    void write(const QByteArray& data);
+
+    QHash<QByteArray, QBackendRemoteObject*> m_subscribedObjects;
+};
+

--- a/plugin/qbackendprocess.cpp
+++ b/plugin/qbackendprocess.cpp
@@ -1,20 +1,13 @@
 #include <QDebug>
-#include <QJsonDocument>
-#include <QJsonArray>
-#include <QJsonObject>
 #include <QLoggingCategory>
+#include <QFile>
 
 #include "qbackendprocess.h"
 
-// #define PROTO_DEBUG
-
 Q_LOGGING_CATEGORY(lcProcess, "backend.process")
-Q_LOGGING_CATEGORY(lcProto, "backend.proto")
-Q_LOGGING_CATEGORY(lcProtoExtreme, "backend.proto.extreme", QtWarningMsg)
 
 QBackendProcess::QBackendProcess(QObject *parent)
-    : QBackendAbstractConnection(parent)
-    , m_completed(false)
+    : QBackendConnection(parent)
 {
 }
 
@@ -70,116 +63,6 @@ void QBackendProcess::componentComplete()
     });
 
     m_process.waitForStarted(); // ### kind of nasty
-    if (m_pendingData.length()) {
-        for (const QByteArray& data : m_pendingData) {
-            write(data);
-        }
-        m_pendingData.clear();
-    }
-
-    connect(&m_process, &QIODevice::readyRead, this, &QBackendProcess::handleModelDataReady);
-    handleModelDataReady();
+    setBackendIo(&m_process, &m_process);
 }
-
-QJsonDocument QBackendProcess::readJsonBlob(int byteCount)
-{
-    QByteArray cmdBuf;
-    while (cmdBuf.length() < byteCount) {
-        qCDebug(lcProtoExtreme) << "Want " << byteCount << " bytes, have " << cmdBuf.length();
-        m_process.waitForReadyRead(10);
-        cmdBuf += m_process.read(byteCount - cmdBuf.length());
-    }
-    Q_ASSERT(cmdBuf.length() == byteCount);
-    QJsonParseError pe;
-    QJsonDocument doc = QJsonDocument::fromJson(cmdBuf, &pe);
-    if (doc.isNull()) {
-        qCWarning(lcProto) << "Bad blob: " << cmdBuf << pe.errorString();
-    }
-    return doc;
-}
-
-void QBackendProcess::handleModelDataReady()
-{
-    while (m_process.canReadLine()) {
-        qCDebug(lcProtoExtreme) << "Reading...";
-        QByteArray cmdBuf = m_process.readLine();
-        if (cmdBuf == "\n") {
-            // ignore
-            continue;
-        }
-
-#if defined(PROTO_DEBUG)
-        qCDebug(lcProto) << "Read " << cmdBuf;
-#endif
-        if (cmdBuf.startsWith("VERSION ")) {
-            // First, remove the newline.
-            cmdBuf.truncate(cmdBuf.length() - 1);
-            QList<QByteArray> parts = cmdBuf.split(' ');
-            Q_ASSERT(parts.length() == 2);
-            qCInfo(lcProcess) << "Connected to backend version " << parts[1];
-        } else if (cmdBuf.startsWith("OBJECT_CREATE ")) {
-            // First, remove the newline.
-            cmdBuf.truncate(cmdBuf.length() - 1);
-
-            QList<QByteArray> parts = cmdBuf.split(' ');
-            Q_ASSERT(parts.length() == 2);
-            QByteArray identifier = QByteArray(parts[1]);
-
-            QJsonDocument doc = readJsonBlob(parts[2].toInt());
-            if (m_subscribedObjects.contains(identifier)) {
-                m_subscribedObjects[identifier]->objectFound(doc);
-            } else {
-                qCWarning(lcProcess) << "Got creation for unsubscribed identifier: " << identifier << doc;
-            }
-        } else if (cmdBuf.startsWith("EMIT ")) {
-            // First, remove the newline.
-            cmdBuf.truncate(cmdBuf.length() - 1);
-
-            QList<QByteArray> parts = cmdBuf.split(' ');
-            Q_ASSERT(parts.length() == 3);
-            QByteArray identifier = QByteArray(parts[1]);
-
-            QJsonDocument doc = readJsonBlob(parts[3].toInt());
-
-            if (m_subscribedObjects.contains(identifier)) {
-                qCDebug(lcProcess) << "Emit " << parts[2] << " on " << parts[1] << doc.toVariant();
-                m_subscribedObjects[identifier]->methodInvoked(parts[2], doc);
-            } else {
-                qCWarning(lcProcess) << "Got method emit for unsubscribed identifier: " << identifier << doc;
-            }
-        }
-    }
-}
-
-void QBackendProcess::write(const QByteArray& data)
-{
-    if (m_process.state() != QProcess::Running) {
-        qCDebug(lcProtoExtreme) << "Write on a non-running process buffered: " << data;
-        m_pendingData.append(data);
-        return;
-    }
-
-#if defined(PROTO_DEBUG)
-    qCDebug(lcProto) << "Writing " << data;
-#endif
-    m_process.write(data);
-}
-
-void QBackendProcess::invokeMethod(const QByteArray& identifier, const QString& method, const QByteArray& jsonData)
-{
-    qCDebug(lcProcess) << "Invoking " << identifier << method << jsonData;
-    QString data = "INVOKE " + identifier + " " + method + " " + QString::number(jsonData.length()) + "\n";
-    write(data.toUtf8());
-    write(jsonData + '\n');
-}
-
-// ### unsubscribe
-void QBackendProcess::subscribe(const QByteArray& identifier, QBackendRemoteObject* object)
-{
-    qCDebug(lcProcess) << "Creating remote object handler " << identifier << " on connection " << this << " for " << object;
-    m_subscribedObjects[identifier] = object;
-    QString data = "SUBSCRIBE " + identifier + "\n";
-    write(data.toUtf8());
-}
-
 

--- a/plugin/qbackendprocess.h
+++ b/plugin/qbackendprocess.h
@@ -4,18 +4,17 @@
 #include <QQmlParserStatus>
 #include <QProcess>
 
-#include "qbackendabstractconnection.h"
-
-class QBackendModel;
+#include "qbackendconnection.h"
 
 // A backend process is one form of RPC. It is not the only form of RPC.
 // It populates the repository with properties, models, and so on.
 
-class QBackendProcess : public QBackendAbstractConnection, public QQmlParserStatus
+class QBackendProcess : public QBackendConnection, public QQmlParserStatus
 {
     Q_OBJECT
     Q_PROPERTY(QString name READ name WRITE setName NOTIFY nameChanged)
     Q_PROPERTY(QStringList args READ args WRITE setArgs NOTIFY argsChanged)
+
 public:
     QBackendProcess(QObject *parent = 0);
 
@@ -29,27 +28,14 @@ protected:
     void classBegin() override;
     void componentComplete() override;
 
-public:
-    void invokeMethod(const QByteArray& identifier, const QString& method, const QByteArray& jsonData) override;
-    void subscribe(const QByteArray& identifier, QBackendRemoteObject* object) override;
-
 signals:
     void nameChanged();
     void argsChanged();
-
-private slots:
-    void handleModelDataReady();
 
 private:
     QString m_name;
     QStringList m_args;
     bool m_completed = false;
     QProcess m_process;
-    QList<QByteArray> m_pendingData;
-
-    QJsonDocument readJsonBlob(int byteCount);
-    void write(const QByteArray& data);
-
-    QHash<QByteArray, QBackendRemoteObject*> m_subscribedObjects;
 };
 


### PR DESCRIPTION
QBackendConnection handles connections for any arbitrary QIODevice pair,
and can construct these via URLs. Currently, only `fd:m,n` is supported.

QBackendProcess inherits from QBackendConnection and can manage execution
of a child process, exactly as it did before, with no API changes.

----

This was a quick effort to get qgoscene working with qbackend, I'm not 100% married to the solution. It does work, though: BackendProcess can be used in exactly the same way, or BackendConnection can be used with a URL to connect on other sockets.