### PR TITLE
Rework connection blocking

### DIFF
--- a/plugin/qbackendconnection.h
+++ b/plugin/qbackendconnection.h
@@ -108,16 +108,14 @@ private:
         WantTypes,
         // Want a QML engine pointer
         WantEngine,
-        // Want a ROOT
-        WantRoot,
-        // Everything (including ROOT and QML engine) done.
-        Established
+        // Ready to handle messages
+        Ready
     };
     ConnectionState m_state = ConnectionState::WantVersion;
     void setState(ConnectionState newState);
 
     QList<QJsonObject> m_pendingMessages;
-    QList<std::function<bool(const QJsonObject&)>> m_syncCallbacks;
+    std::function<bool(const QJsonObject&)> m_syncCallback;
     QJsonObject m_syncResult;
 
     // Hash of identifier -> proxy object for all existing objects

--- a/plugin/qbackendmodel.cpp
+++ b/plugin/qbackendmodel.cpp
@@ -185,7 +185,7 @@ QJSValue BackendModelPrivate::fetchRow(int row)
     qCDebug(lcModel) << "blocking to fetch rows" << start << "to" << end << "to get data for row" << row;
 
     QMetaObject::invokeMethod(m_modelData, "requestRows", Q_ARG(int, start), Q_ARG(int, end-start+1));
-    m_connection->waitForMessage(
+    m_connection->waitForMessage("model_emit",
         [&](const QJsonObject &msg) {
             return msg.value("command").toString() == "EMIT" &&
                    msg.value("method").toString() == "modelRowData" &&

--- a/plugin/qbackendobject.cpp
+++ b/plugin/qbackendobject.cpp
@@ -158,7 +158,6 @@ void BackendObjectPrivate::classBegin()
     if (!m_connection->qmlEngine()) {
         qCDebug(lcObject) << "setting engine" << qmlEngine(m_object) << "for connection at object instantiation";
         m_connection->setQmlEngine(qmlEngine(m_object));
-        m_connection->blockReadSignals(false);
     }
 }
 


### PR DESCRIPTION
Previously, message processing was blocked via signalling. When blocked,
only a message that was being waited for could be processed and anything
else was held pending.

Now, we have a connection state. When setting up the connection, any
message that is received is held pending (regardless of whether or not
there's a sync callback for it).