### PR TITLE
Make QObject a struct

### DIFF
--- a/backend/model.go
+++ b/backend/model.go
@@ -79,7 +79,7 @@ func (m *Model) dataSource() ModelDataSource {
 		return nil
 	}
 
-	if ds, ok := impl.Object.(ModelDataSource); ok {
+	if ds, ok := impl.object.(ModelDataSource); ok {
 		return ds
 	} else {
 		// XXX Object must implement ModelRowSource; warn/error/panic/something

--- a/backend/model_test.go
+++ b/backend/model_test.go
@@ -26,17 +26,12 @@ var _ ModelDataSource = &CustomModel{}
 // Tests
 func TestModelType(t *testing.T) {
 	model := &CustomModel{}
-	if isQObject, _ := QObjectFor(model); !isQObject {
-		t.Error("CustomModel type is not detected as a QObject")
+	if _, ok := ((interface{})(model)).(AnyQObject); !ok {
+		t.Errorf("CustomModel does not implement AnyQObject")
 	}
 
 	if err := dummyConnection.InitObject(model); err != nil {
 		t.Errorf("CustomModel object initialization failed: %s", err)
-	}
-
-	impl := objectImplFor(model)
-	if impl.Object != model {
-		t.Errorf("CustomModel QObject does not point back to model; expected %v, Object is %v", model, impl.Object)
 	}
 
 	if model.ModelAPI == nil {

--- a/backend/object.go
+++ b/backend/object.go
@@ -500,17 +500,17 @@ func (o *QObject) MarshalJSON() ([]byte, error) {
 func (o *QObject) marshalObject() (map[string]interface{}, error) {
 	data := make(map[string]interface{})
 
+	// Zero out all child ref counts
+	for k, _ := range o.refChildren {
+		o.refChildren[k] = 0
+	}
+
 	value := reflect.Indirect(reflect.ValueOf(o.object))
 	for name, index := range o.typeInfo.propertyFieldIndex {
 		field := value.FieldByIndex(index)
 		if refs, err := o.initObjectsUnder(field); err != nil {
 			return nil, err
 		} else {
-			// Zero out all child ref counts
-			for k, _ := range o.refChildren {
-				o.refChildren[k] = 0
-			}
-
 			// Add references from refs
 			for _, id := range refs {
 				if _, existing := o.refChildren[id]; !existing {

--- a/backend/object.go
+++ b/backend/object.go
@@ -413,6 +413,9 @@ func (o *QObject) Emit(signal string, args ...interface{}) {
 }
 
 func (o *QObject) emitReflected(signal string, args []reflect.Value) {
+	if !o.ref {
+		return
+	}
 	unwrappedArgs := make([]interface{}, 0, len(args))
 	for _, a := range args {
 		unwrappedArgs = append(unwrappedArgs, a.Interface())
@@ -432,7 +435,7 @@ func (o *QObject) Changed(property string) {
 // ResetProperties is effectively identical to emitting the Changed
 // signal for all properties of the object.
 func (o *QObject) ResetProperties() {
-	if !o.Referenced() {
+	if !o.ref {
 		return
 	}
 	o.c.sendUpdate(o)

--- a/backend/object_test.go
+++ b/backend/object_test.go
@@ -20,6 +20,7 @@ type BasicQObject struct {
 	StringData string
 	StructData BasicStruct
 	Child      *BasicQObject
+	Signal     func()
 
 	initWasCalled bool
 }
@@ -39,6 +40,11 @@ func TestMain(m *testing.M) {
 func TestQObjectInit(t *testing.T) {
 	q := &BasicQObject{}
 
+	// These should silently do nothing on an uninitialized object
+	q.Emit("signal")
+	q.ResetProperties()
+	q.Changed("stringData")
+
 	if err := dummyConnection.InitObject(q); err != nil {
 		t.Errorf("QObject initialization failed: %s", err)
 	}
@@ -47,8 +53,9 @@ func TestQObjectInit(t *testing.T) {
 		t.Error("Embedded QObject still blank after initialization")
 	}
 
-	// XXX Identifier uniqueness
-	// XXX Signal initialization
+	if q.Signal == nil {
+		t.Error("Signal function not initialized by QObject")
+	}
 
 	if !q.initWasCalled {
 		t.Error("QObjectHasInit initialization function not called")

--- a/backend/type_test.go
+++ b/backend/type_test.go
@@ -1,0 +1,77 @@
+package qbackend
+
+import (
+	"reflect"
+	"testing"
+)
+
+type Simple struct {
+	Simple string
+}
+
+type Fields struct {
+	String    string
+	Bytes     []byte
+	Strings   []string
+	Map       map[string]string
+	Struct    Simple
+	Ptr       *Simple
+	Object    *TestStruct
+	Interface interface{}
+}
+
+type TestStruct struct {
+	QObject
+	Fields
+
+	unexported  bool
+	Ignored     bool `qbackend:"-"`
+	IgnoredJSON bool `json:"-"`
+
+	Signal       func()
+	SignalParams func(a, b int) `qbackend:"a,b"`
+}
+
+func TestParseTypes(t *testing.T) {
+	obj := &TestStruct{}
+	objType := reflect.TypeOf(*obj)
+	info, err := parseType(objType)
+	if err != nil {
+		t.Errorf("parseType failed: %v", err)
+	}
+
+	t.Logf("parsed type: %s", info)
+
+	expectProp := []string{"string", "bytes", "strings", "map", "struct", "ptr", "object", "interface"}
+	expectMethod := []string{}
+	expectSignal := []string{"signal", "signalParams"}
+
+	for _, p := range expectProp {
+		if _, exists := info.Properties[p]; !exists {
+			t.Errorf("Expected property '%s' to exist", p)
+		}
+
+		expectSignal = append(expectSignal, typeFieldChangedName(p))
+	}
+	if len(expectProp) != len(info.Properties) {
+		t.Errorf("Expected %d properties but type info has %d", len(expectProp), len(info.Properties))
+	}
+
+	for _, p := range expectMethod {
+		if _, exists := info.Methods[p]; !exists {
+			t.Errorf("Expected method '%s' to exist", p)
+		}
+	}
+	if len(expectMethod) != len(info.Methods) {
+		t.Errorf("Expected %d methods but type info has %d", len(expectMethod), len(info.Methods))
+	}
+
+	for _, p := range expectSignal {
+		if _, exists := info.Signals[p]; !exists {
+			t.Errorf("Expected signal '%s' to exist", p)
+		}
+	}
+	if len(expectSignal) != len(info.Signals) {
+		t.Errorf("Expected %d signals but type info has %d", len(expectSignal), len(info.Signals))
+	}
+}


### PR DESCRIPTION
```
Convert QObject from an embedded interface to a struct. This should help
avoid the pre-initialization QObject API issues.

As an interesting side effect, it's technically possible to make a type
QObject without actually embedding, as long as it implements AnyQObject.
I don't know if that has any value, though.

This doesn't get into any API changes just yet.
```

Also added some unit tests and fixed this:
```
marshalObject is meant to keep a count of the number of references from
that object to any other QObject, as part of the object reference
counting for safe garbage collection.

This was being cleared repeatedly during the marshalling, so its value
would generally be completely wrong and likely lead to dangling
references.
```
Which leads to some scary-sounding potential refcount/garbage collection issues.