### PR TITLE
Provide return values for methods via JS promises

### DIFF
--- a/backend/type.go
+++ b/backend/type.go
@@ -41,6 +41,7 @@ type typeMethod struct {
 
 var knownTypeInfo = make(map[reflect.Type]*typeInfo)
 var qobjInterfaceType = reflect.TypeOf((*AnyQObject)(nil)).Elem()
+var errorType = reflect.TypeOf((*error)(nil)).Elem()
 
 func typeIsQObject(t reflect.Type) bool {
 	return reflect.PtrTo(t).Implements(qobjInterfaceType)
@@ -228,6 +229,12 @@ func parseType(t reflect.Type) (*typeInfo, error) {
 		}
 		for p := 0; p < methodType.NumOut(); p++ {
 			outType := methodType.Out(p)
+
+			if p == methodType.NumOut()-1 && outType == errorType {
+				// Skip the last output if it is an error; invoke will handle
+				// these separately.
+				continue
+			}
 			tm.Return = append(tm.Return, typeInfoTypeName(outType))
 		}
 

--- a/backend/type_test.go
+++ b/backend/type_test.go
@@ -32,6 +32,10 @@ type TestStruct struct {
 	SignalParams func(a, b int) `qbackend:"a,b"`
 }
 
+func (t *TestStruct) RealMethod(arg1 int, arg2 []string) (*TestStruct, error) {
+	return t, nil
+}
+
 func TestParseTypes(t *testing.T) {
 	obj := &TestStruct{}
 	objType := reflect.TypeOf(*obj)
@@ -43,7 +47,7 @@ func TestParseTypes(t *testing.T) {
 	t.Logf("parsed type: %s", info)
 
 	expectProp := []string{"string", "bytes", "strings", "map", "struct", "ptr", "object", "interface"}
-	expectMethod := []string{}
+	expectMethod := []string{"realMethod"}
 	expectSignal := []string{"signal", "signalParams"}
 
 	for _, p := range expectProp {
@@ -64,6 +68,16 @@ func TestParseTypes(t *testing.T) {
 	}
 	if len(expectMethod) != len(info.Methods) {
 		t.Errorf("Expected %d methods but type info has %d", len(expectMethod), len(info.Methods))
+	}
+	if m, ok := info.Methods["realMethod"]; ok {
+		if len(m.Args) != 2 {
+			t.Errorf("Method expected %d args but has %d: %v", 2, len(m.Args), m.Args)
+		}
+		if len(m.Return) != 2 {
+			t.Errorf("Method expected %d return values but has %d: %v", 2, len(m.Return), m.Return)
+		}
+	} else {
+		t.Errorf("Missing method 'realMethod'")
 	}
 
 	for _, p := range expectSignal {

--- a/examples/people/main.qml
+++ b/examples/people/main.qml
@@ -110,13 +110,36 @@ Window {
         width: parent.width
 
         Button {
+            id: addButton
             height: implicitHeight * 2
             width: parent.width
             text: "Add"
             onClicked: {
-                personModel.addPerson()
+                // Calls the AddPerson method of the Go PersonModel. This returns a Promise,
+                // and asynchronously the return values/error from that method.
+                personModel.addPerson(randomName(), randomName()).then(
+                    person => {
+                        console.log("Added a new person", person.firstName, person.lastName,
+                                    "of", person.age, "years old")
+                    },
+                    error => {
+                        // Try adding a person with an empty name
+                        console.warn("Error adding a person:", error)
+                    }
+                )
             }
         }
+    }
+
+    function randomName() {
+        var names = [ "Shackleford", "Quinn", "Declan", "Holden Rosen", "Dar", "Sky",
+                      "Taggart", "Dallas", "Colby", "Wheaton", "Tanner", "Corson",
+                      "Kadin", "Whitten", "Conn", "Gaige", "Raines", "Hampton",
+                      "Stanwick", "Commandant", "Smartwood", "Stucker", "Grupp",
+                      "Sleeper", "Dupree", "Eymer", "Creamer", "Hamwey", "Jackoboice",
+                      "Elwood", "Kealey", "Kightlinger", "McCune", "Curry", "Barber",
+                      "Shamburger", "Brannon" ]
+        return names[~~(names.length * Math.random())]
     }
 }
 

--- a/examples/people/people.go
+++ b/examples/people/people.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"errors"
+
 	"github.com/CrimsonAS/qbackend/backend"
 	"github.com/CrimsonAS/qbackend/backend/qmlscene"
 )
@@ -43,16 +45,20 @@ func (this *PersonModel) RoleNames() []string {
 	}
 }
 
-func (this *PersonModel) AddPerson() {
+func (this *PersonModel) AddPerson(firstName, lastName string) (*Person, error) {
 	desiredAge := 0
 	if len(this.people) > 0 {
 		desiredAge = this.people[len(this.people)-1].Age + 1
 	}
-	p := &Person{FirstName: "John", LastName: "Brooks", Age: desiredAge}
+	if firstName == "" || lastName == "" {
+		return nil, errors.New("missing first/last name for new person")
+	}
+	p := &Person{FirstName: firstName, LastName: lastName, Age: desiredAge}
 	this.people = append(this.people, p)
 	this.Inserted(len(this.people)-1, 1)
 	this.Count = len(this.people)
 	this.Changed("Count")
+	return p, nil
 }
 
 func (this *PersonModel) RemovePerson(idx int) {

--- a/plugin/plugin.pro
+++ b/plugin/plugin.pro
@@ -14,7 +14,8 @@ SOURCES += \
     qbackendconnection.cpp \
     qbackendprocess.cpp \
     qbackendobject.cpp \
-    qbackendmodel.cpp
+    qbackendmodel.cpp \
+    promise.cpp
 
 HEADERS += \
     plugin.h \
@@ -24,6 +25,7 @@ HEADERS += \
     qbackendobject_p.h \
     qbackendmodel.h \
     qbackendmodel_p.h \
-    instantiable.h
+    instantiable.h \
+    promise.h
 
 load(qml_plugin)

--- a/plugin/promise.cpp
+++ b/plugin/promise.cpp
@@ -1,0 +1,44 @@
+#include "promise.h"
+#include <QLoggingCategory>
+#include <QDebug>
+
+Q_DECLARE_LOGGING_CATEGORY(lcObject);
+
+Promise::Promise(QJSEngine *engine)
+{
+    // XXX Could QJSValue::callAsConstructor avoid evaluation here?
+    QJSValue v = engine->evaluate(" \
+        var r = ({}); \
+        r['promise'] = new Promise(function(resolve, reject) { \
+            r['resolve'] = resolve; \
+            r['reject'] = reject; \
+        }); \
+        r; \
+    ");
+    if (v.isError()) {
+        qCCritical(lcObject) << "Failed to create promise:" << v.toString();
+        return;
+    }
+
+    m_value = v.property("promise");
+    m_resolve = v.property("resolve");
+    m_reject = v.property("reject");
+    if (!m_value.isObject() || !m_resolve.isCallable() || !m_reject.isCallable()) {
+        qCCritical(lcObject) << "Failed to create promise" << m_value.isObject() << m_resolve.isCallable() << m_reject.isCallable();
+        return;
+    }
+}
+
+void Promise::resolve(const QJSValue &result)
+{
+    Q_ASSERT(m_resolve.isCallable());
+    m_resolve.call({result});
+    m_resolve = m_reject = QJSValue();
+}
+
+void Promise::reject(const QJSValue &error)
+{
+    Q_ASSERT(m_resolve.isCallable());
+    m_reject.call({error});
+    m_resolve = m_reject = QJSValue();
+}

--- a/plugin/promise.h
+++ b/plugin/promise.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <QJSEngine>
+
+class Promise
+{
+public:
+    Promise(QJSEngine *engine);
+
+    QJSValue value() const { return m_value; }
+    void resolve(const QJSValue &result);
+    void reject(const QJSValue &error);
+
+private:
+    QJSValue m_value;
+    QJSValue m_resolve;
+    QJSValue m_reject;
+};

--- a/plugin/qbackendconnection.h
+++ b/plugin/qbackendconnection.h
@@ -25,6 +25,9 @@ public:
 
     // Called when a method is invoked on this object
     virtual void methodInvoked(const QString& method, const QJsonArray& params) = 0;
+
+    // Called with the return value from a previously invoked method
+    virtual void methodReturned(const QByteArray& returnId, const QJsonValue& value, bool isError) = 0;
 };
 
 class QBackendConnection : public QObject, public QQmlParserStatus
@@ -54,7 +57,8 @@ public:
 
     void registerTypes(const char *uri);
 
-    void invokeMethod(const QByteArray& identifier, const QString& method, const QJsonArray& params);
+    void invokeMethod(const QByteArray& objectIdentifier, const QString& method, const QJsonArray& params);
+    QByteArray invokeMethodWithReturn(const QByteArray& objectIdentifier, const QString& method, const QJsonArray& params);
     void addObjectProxy(const QByteArray& identifier, QBackendRemoteObject* object);
     void addObjectInstantiated(const QString &typeName, const QByteArray& identifier, QBackendRemoteObject* object);
     void removeObject(const QByteArray& identifier, QBackendRemoteObject *object);

--- a/plugin/qbackendobject_p.h
+++ b/plugin/qbackendobject_p.h
@@ -6,6 +6,8 @@
 #include <QJSValue>
 #include "qbackendconnection.h"
 
+class Promise;
+
 class BackendObjectPrivate : public QBackendRemoteObject
 {
     Q_OBJECT
@@ -21,6 +23,8 @@ public:
     bool m_dataReady = false;
     bool m_waitingForData = false;
 
+    QHash<QByteArray,Promise*> m_promises;
+
     BackendObjectPrivate(QObject *object, QBackendConnection *connection, const QByteArray &identifier);
     BackendObjectPrivate(const char *typeName, QObject *object, QBackendConnection *connection);
     virtual ~BackendObjectPrivate();
@@ -28,6 +32,7 @@ public:
     QObject *object() const override { return m_object; }
     void objectFound(const QJsonObject& object) override;
     void methodInvoked(const QString& method, const QJsonArray& params) override;
+    void methodReturned(const QByteArray& returnId, const QJsonValue& value, bool isError) override;
     void resetData(const QJsonObject &data);
 
     int metacall(QMetaObject::Call c, int id, void **argv);


### PR DESCRIPTION
All method calls on a backend object from QML will now return a javascript Promise, which will receive any return values or errors from the backend method. Multiple return values are provided as an array. If the final return type of a backend method is `error`, the promise will be rejected with that error if non-nil. If that error is nil, it will be removed from the return values.

As of now, this is missing examples/documentation/tests.

This will resolve #13.