### PR TITLE
Update Object docs for method promises and QObject init

### DIFF
--- a/backend/doc.go
+++ b/backend/doc.go
@@ -34,8 +34,8 @@
 //  property int numSteps: demo.steps.length
 //  onClicked: { demo.run(); demo.steps = [] }
 //
-// QObjects are used by passing them (by pointer) to the frontend in the properties or signals of other
-// objects. They do not need to be initialized explicitly, and they will be garbage collected normally once
+// QObjects are used by passing them (by pointer) to the frontend in properties, signals, and return values of
+// other objects. They do not need to be initialized explicitly, and they will be garbage collected normally once
 // there are no remaining references to the object from Go or QML. Generally, there is no need to treat them
 // differently from any other type.
 //
@@ -72,6 +72,7 @@
 //      value: 123
 //      onValueChanged: { ... }
 //  }
+//
 // Optional interface methods allow the QObject to initialize values and act when construction is completed or
 // after QML destruction.
 //

--- a/backend/object.go
+++ b/backend/object.go
@@ -121,18 +121,19 @@ const (
 // Serialization of the properties of a QObject happens internally. These details
 // may change.
 //
-// Initialization & QObject Methods
+// Initialization
 //
 // QObjects usually don't need explicit initialization. When a QObject is encountered
 // in the properties or parameters of another object, it's initialized automatically.
-// Initialization assigns the embedded QObject interface, a unique object ID, and sets
-// handlers on any nil signal fields. Objects can be initialized immediately with
-// Connection.InitObject or Connection.InitObjectId.
+// Initialization assigns a unique object ID and sets handlers on any nil signal
+// fields (so they can be called directly). It's safe to call QObject's methods
+// on an uninitialized object; they generally have no effect.
 //
-// The embedded QObject is initially nil, meaning that calls to any of QObject's methods
-// will panic. Any unassigned signals will also be nil until the QObject is initialized.
-// Take care to check before calling these methods if the object might not have been
-// used.
+// Objects can be initialized immediately with Connection. A custom object ID can
+// be set with Connection.InitObjectId(). This can be useful when wrapping an
+// external Go type with a QObject type, because keeping a list of pointers would
+// prevent garbage collection. The QObject can be found by ID with Connection.Object()
+// if it still exists.
 //
 // Garbage Collection
 //


### PR DESCRIPTION
It's probably worth cleaning up the godoc syntax at some point, but.